### PR TITLE
Fix: Replace deprecated np.round_ with np.round function

### DIFF
--- a/spectrum_utils/spectrum.py
+++ b/spectrum_utils/spectrum.py
@@ -75,7 +75,7 @@ class MsmsSpectrumJit:
     def round(
         self, decimals: int = 0, combine: str = "sum"
     ) -> "MsmsSpectrumJit":
-        mz_round = np.round_(self._mz, decimals, np.empty_like(self._mz))
+        mz_round = np.round(self._mz, decimals=decimals)
         mz_unique = np.unique(mz_round)
         if len(mz_unique) == len(mz_round):
             self._mz = mz_unique

--- a/tests/spectrum_test.py
+++ b/tests/spectrum_test.py
@@ -49,7 +49,7 @@ def test_mz_array():
     mz = np.random.uniform(100, 1400, num_peaks).tolist()
     intensity = np.random.lognormal(0, 1, num_peaks)
     spec = spectrum.MsmsSpectrum("test_spectrum", 500, 2, mz, intensity)
-    assert type(spec.mz) == np.ndarray
+    assert isinstance(spec.mz, np.ndarray)
     with pytest.raises(AttributeError):
         spec.mz = np.random.uniform(100, 1400, num_peaks)
 
@@ -59,7 +59,7 @@ def test_intensity_array():
     mz = np.random.uniform(100, 1400, num_peaks)
     intensity = np.random.lognormal(0, 1, num_peaks).tolist()
     spec = spectrum.MsmsSpectrum("test_spectrum", 500, 2, mz, intensity)
-    assert type(spec.intensity) == np.ndarray
+    assert isinstance(spec.intensity, np.ndarray)
     with pytest.raises(AttributeError):
         spec.intensity = np.random.lognormal(0, 1, num_peaks)
 


### PR DESCRIPTION
## Fixes #75

## Changes
- Resolves the NumPy 2.0+ deprecation warning by replacing the deprecated `np.round_` with the recommended `np.round` function.
- Fixed style issue in test_intensity_array to use `isinstance()` instead of type comparison

## Testing
All tests related to the `round()` method pass successfully:
- test_round_no_merge
- test_round_merge_len
- test_round_merge_sum
- test_round_merge_max