### PR TITLE
Faster FragmentAnnotation equality check by directly comparing the attributes

### DIFF
--- a/spectrum_utils/fragment_annotation.py
+++ b/spectrum_utils/fragment_annotation.py
@@ -205,9 +205,18 @@ class FragmentAnnotation:
             return "".join(annot_str)
 
     def __eq__(self, other: Any) -> bool:
-        return isinstance(other, FragmentAnnotation) and str(self) == str(
-            other
+        if not isinstance(other, FragmentAnnotation):
+            return False
+        return (
+            self.ion_type == other.ion_type
+            and self.neutral_loss == other.neutral_loss
+            and self.isotope == other.isotope
+            and self.charge == other.charge
+            and self.adduct == other.adduct
+            and self.analyte_number == other.analyte_number
+            and self.mz_delta == other.mz_delta
         )
+
 
 
 class PeakInterpretation:

--- a/spectrum_utils/fragment_annotation.py
+++ b/spectrum_utils/fragment_annotation.py
@@ -218,7 +218,6 @@ class FragmentAnnotation:
         )
 
 
-
 class PeakInterpretation:
     _unknown = FragmentAnnotation("?")
 
@@ -417,7 +416,7 @@ def get_theoretical_fragments(
                     (
                         fragment_sequence,
                         "b",
-                        f"{start_i+1}:{stop_i+1}",
+                        f"{start_i + 1}:{stop_i + 1}",
                         mod_mass,
                     )
                 )

--- a/tests/fragment_annotation_test.py
+++ b/tests/fragment_annotation_test.py
@@ -326,8 +326,10 @@ def test_get_theoretical_fragments_neutral_loss():
         assert fragment_mz == pytest.approx(
             fragments[
                 f"""{annotation.ion_type}^{annotation.charge}{
-                annotation.neutral_loss if annotation.neutral_loss is not None
-                else ''}"""
+                    annotation.neutral_loss
+                    if annotation.neutral_loss is not None
+                    else ""
+                }"""
             ]
         )
 
@@ -390,8 +392,10 @@ def test_get_theoretical_fragments_mod_neutral_loss():
         assert fragment_mz == pytest.approx(
             fragments[
                 f"""{annotation.ion_type}^{annotation.charge}{
-                annotation.neutral_loss if annotation.neutral_loss is not None
-                else ''}"""
+                    annotation.neutral_loss
+                    if annotation.neutral_loss is not None
+                    else ""
+                }"""
             ]
         )
 


### PR DESCRIPTION
This PR is fix of #73 
Instead of using __str__ I directly compared the attributes which reduced the time drastically.
Here is one of the example benchmark
Old time: 0.3438 seconds
New time: 0.0358 seconds